### PR TITLE
Implement extra honeypot tricks

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ nohup python honeypot.py &
 ```
 
 The server listens on port `2121` by default and writes logs to `honeypot.log`.
-Set `HONEYFTP_PORT`, `SLACK_WEBHOOK` or `SMTP_SERVER` environment variables to
-enable alerts or change the port.
+Set `HONEYFTP_PORT` to change the port. You can also define `KNOCK_SEQ` (comma
+separated ports) to require a port-knock sequence before the honeypot starts.
+`SLACK_WEBHOOK` or `SMTP_SERVER` enable alerts.
 
 ## Deployment on Proxmox
 
@@ -45,7 +46,8 @@ enable alerts or change the port.
 4. Lancez le script en tâche de fond :
 
    ```bash
-   HONEYFTP_PORT=2121 SLACK_WEBHOOK=<url_webhook> nohup python honeypot.py &
+   HONEYFTP_PORT=2121 KNOCK_SEQ=1111,2222,3333 \
+   SLACK_WEBHOOK=<url_webhook> nohup python honeypot.py &
    ```
 
 Le service sera alors exposé sur le port choisi à l'intérieur de la VM ou du

--- a/attaquant.py
+++ b/attaquant.py
@@ -53,8 +53,8 @@ def do_nlst(ftp):
         files = ftp.nlst(".")
         files = [f.lstrip("./") for f in files]
         print(Fore.CYAN + "← FILES:")
-        for fn in files:
-            print("   •", fn)
+        for i, fn in enumerate(files, 1):
+            print(Fore.CYAN + f"  {i:2d}) {fn}")
     except Exception as e:
         print(Fore.RED + "× NLST failed:", e)
 
@@ -68,6 +68,7 @@ def do_retr(ftp):
         with open(os.path.expanduser(out), "wb") as f:
             ftp.retrbinary(f"RETR {fn}", f.write)
         print(Fore.GREEN + f"✓ {fn} → {out}")
+        print(Fore.YELLOW + "(check the file for fake data if any)")
     except Exception as e:
         print(Fore.RED + "× RETR failed:", e)
 


### PR DESCRIPTION
## Summary
- add fake files and uploads directory
- simulate BOF/DEBUG/SQLMAP in SITE command
- inject fake files into NLST and handle fake RETR
- support optional port knocking before starting FTPS
- tweak attacker client UI
- document new `KNOCK_SEQ` variable

## Testing
- `python -m py_compile honeypot.py attaquant.py`

------
https://chatgpt.com/codex/tasks/task_e_685ded073ba48331889cc236e57b1965