### PR TITLE
Fix passive port range & update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+virtual_fs/
+sessions/
+*.log

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Ensure the port is open in your firewall:
 sudo ufw allow 2121/tcp
 ```
 
+Data connections use a passive range of **60000‑60100**. If those ports are
+blocked, commands like `NLST` or `RETR` will hang with a timeout. Make sure the
+range is reachable, especially when testing locally with the attacker script.
+
 ## Deployment on Proxmox
 
 1. Créez un conteneur ou une VM Debian/Ubuntu sur votre hôte Proxmox.

--- a/honeypot.py
+++ b/honeypot.py
@@ -224,8 +224,12 @@ def start_ftp():
     def _listen_ssl(port, factory, *a, **kw):
         return reactor.listenSSL(port, factory, ctx, *a, **kw)
     HoneyFTP.listenFactory = staticmethod(_listen_ssl)
-    HoneyFTP.passivePortRange = range(60000, 60100)
-    endpoints.SSL4ServerEndpoint(reactor, PORT, ctx).listen(HoneyFTPFactory(p, ctx))
+    port_range = range(60000, 60100)
+    HoneyFTP.passivePortRange = port_range
+    HoneyFTPFactory.passivePortRange = port_range
+    factory = HoneyFTPFactory(p, ctx)
+    factory.passivePortRange = port_range
+    endpoints.SSL4ServerEndpoint(reactor, PORT, ctx).listen(factory)
     logging.info("Honeypot FTPS listening on port %s", PORT)
 
 def randomize_fs(max_dirs=3, max_files=2, max_total=50):


### PR DESCRIPTION
## Summary
- ensure passive connections listen on ports 60000-60100
- document the passive port range
- ignore runtime artifacts

## Testing
- `python -m py_compile honeypot.py attaquant.py`

------
https://chatgpt.com/codex/tasks/task_e_68613aa81cc48331a0bc72c0d7be24f0