### PR TITLE
Enhance HoneyFTP file system and attacker tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Slack or SMTP. Each connection has its own session log for forensic analysis.
 - Journaux colorés sur la console et `honeypot.log` au format texte
 - Commandes supplémentaires `SITE UPTIME` et `SITE STATS`
 - Script `attaquant.py` exécutable en mode non interactif (`--script` ou `--commands`)
+- Arborescence de fichiers crédible (finance, projets, backups…) avec honeytokens
 
 
 ## Requirements
@@ -113,6 +114,10 @@ python attaquant.py --script attack
 python attaquant.py --commands commandes.txt
 ```
 
+Un compte factice `attacker/secret` est accessible **uniquement après**
+envoi de la séquence de port‑knocking. L'option `21` du menu tente de
+deviner cette séquence automatiquement.
+
 Le menu interactif accepte les valeurs **0 à 20** :
 
 
@@ -138,6 +143,7 @@ Le menu interactif accepte les valeurs **0 à 20** :
 |17|Rejouer une liste de commandes|
 |19|`SITE UPTIME` – durée de fonctionnement|
 |20|`SITE STATS` – statistiques globales|
+|21|Recherche de la séquence de knock|
 
 L'option `18` quitte le client.
 

--- a/attaquant.py
+++ b/attaquant.py
@@ -46,6 +46,24 @@ def do_knock(host, port=2121):
     check_access(host, port)
 
 
+def brute_knock(host, port=2121, start=4015, end=4030):
+    """Attempt to discover the knock sequence by trying consecutive triples."""
+    global unlocked
+    print(Fore.MAGENTA + "→ Brute-forcing knock ports…")
+    for base in range(start, end - 2):
+        seq = [base, base + 1, base + 2]
+        for p in seq:
+            s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            s.sendto(b"", (host, p))
+            s.close()
+        time.sleep(1)
+        if check_access(host, port):
+            unlocked = True
+            print(Fore.GREEN + f"✓ Sequence trouvée : {seq}")
+            return
+    print(Fore.RED + "× Sequence introuvable")
+
+
 def make_ftps(host, port, retries=3):
     """Établit la connexion FTPS implicite."""
     ctx = ssl._create_unverified_context()
@@ -403,6 +421,7 @@ def main():
 18) Quitter
 19) SITE UPTIME
 20) SITE STATS
+21) Brute-force knock
 """)
         cmd = input("Votre choix > ").strip()
 
@@ -463,6 +482,8 @@ def main():
             do_site_uptime(ftp)
         elif cmd == "20" and ftp:
             do_site_stats(ftp)
+        elif cmd == "21":
+            brute_knock(args.host, args.port)
         else:
             print(Fore.RED + "→ Choix invalide ou pas de connexion active.")
 


### PR DESCRIPTION
## Summary
- generate a more realistic corporate file tree at startup
- add additional honeytokens and alert on session token reads
- expose a brute-force knock helper in the attacker script
- document new features and attacker account in README

## Testing
- `python -m py_compile honeypot.py attaquant.py`

------
https://chatgpt.com/codex/tasks/task_e_6865314b10c08331bd9e54bcbbc2168e