### PR TITLE
Add dashboard and honeypot admin shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,19 @@ Le menu interactif accepte les valeurs **0 à 20** :
 
 L'option `18` quitte le client.
 
+## Commandes de gestion
+
+Un script `manage.py` centralise les différentes actions :
+
+```bash
+./manage.py run --mode cli   # lancer le shell FTP interactif
+./manage.py run --mode web   # démarrer le tableau de bord Flask
+./manage.py honeypot         # serveur FTPS avec shell admin
+```
+
+Le mode *web* affiche la liste des sessions, les derniers logs et un
+récapitulatif des attaques enregistrées.
+
 ## Améliorations possibles
 
 - Gestion d'utilisateurs avec quotas individuels

--- a/manage.py
+++ b/manage.py
@@ -5,6 +5,7 @@ BASE = os.path.dirname(os.path.abspath(__file__))
 PID_FILE = os.path.join(BASE, 'honeypot.pid')
 LOG_FILE = os.path.join(BASE, 'honeypot.log')
 
+
 def start():
     if os.path.exists(PID_FILE):
         print('Honeypot already running')
@@ -36,7 +37,7 @@ def logs():
         print('No log file')
 
 
-def sessions():
+def sessions_cmd():
     sess_dir = os.path.join(BASE, 'sessions')
     if not os.path.isdir(sess_dir):
         print('No sessions directory')
@@ -46,18 +47,42 @@ def sessions():
             print(name)
 
 
+def run_client(mode):
+    cmd = [sys.executable, 'attacker_shell.py', '--mode', mode]
+    subprocess.call(cmd)
+
+
+def honeypot_shell():
+    subprocess.call([sys.executable, 'honeypot.py', '--shell'])
+
+
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument('cmd', choices=['start', 'stop', 'logs', 'sessions'])
+    sub = ap.add_subparsers(dest='cmd', required=True)
+
+    rp = sub.add_parser('run', help='start attacker client or dashboard')
+    rp.add_argument('--mode', choices=['cli', 'web'], default='cli')
+
+    sub.add_parser('honeypot', help='start honeypot with admin shell')
+    sub.add_parser('start', help='start honeypot in background')
+    sub.add_parser('stop', help='stop honeypot')
+    sub.add_parser('logs', help='tail honeypot log')
+    sub.add_parser('sessions', help='list session files')
+
     args = ap.parse_args()
-    if args.cmd == 'start':
+
+    if args.cmd == 'run':
+        run_client(args.mode)
+    elif args.cmd == 'honeypot':
+        honeypot_shell()
+    elif args.cmd == 'start':
         start()
     elif args.cmd == 'stop':
         stop()
     elif args.cmd == 'logs':
         logs()
     elif args.cmd == 'sessions':
-        sessions()
+        sessions_cmd()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- make `attacker_shell.py` directly executable with auto-install of `rich`
- add optional Flask dashboard and default IP
- provide admin shell in `honeypot.py`
- overhaul `manage.py` to orchestrate client and honeypot
- document new management commands