### PR TITLE
Fix PDF generation and streamline admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,16 +150,14 @@ L'option `18` quitte le client.
 
 ## Commandes de gestion
 
-Un script `manage.py` centralise les différentes actions :
+L'administration se fait directement depuis `honeypot.py` :
 
 ```bash
-./manage.py run --mode cli   # lancer le shell FTP interactif
-./manage.py run --mode web   # démarrer le tableau de bord Flask
-./manage.py honeypot         # serveur FTPS avec shell admin
+python3 honeypot.py
 ```
 
-Le mode *web* affiche la liste des sessions, les derniers logs et un
-récapitulatif des attaques enregistrées.
+Un menu propose de démarrer ou arrêter le serveur, consulter les logs,
+lister ou afficher les sessions et voir les statistiques globales.
 
 ## Améliorations possibles
 


### PR DESCRIPTION
## Summary
- use the `fpdf` library instead of `fpdf2`
- wrap PDF lure creation in try/except
- expose `show_session(id)` and ask for ID in the menu
- remove references to `manage.py` in docs

## Testing
- `python3 -m py_compile honeypot.py`
- `python3 honeypot.py <<'EOF'
0
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6866fb0b3a348331b5317a3c512843f5