### PR TITLE
Fix LIST without path

### DIFF
--- a/honeypot.py
+++ b/honeypot.py
@@ -771,7 +771,9 @@ class HoneyFTP(ftp.FTP):
 
     def ftp_NLST(self, path):
         peer = self.transport.getPeer().host
-        p = path or self.workingDirectory
+        # When no path is supplied, use an empty string so validate_path()
+        # receives a string instead of the working directory list.
+        p = path or ""
         try:
             _, rel = validate_path(p, self.workingDirectory)
         except ValueError:


### PR DESCRIPTION
## Summary
- fix NLST to normalize empty path argument

## Testing
- `python -m py_compile honeypot.py`

------
https://chatgpt.com/codex/tasks/task_e_6869191eaf348331b55631e7ef5ae29c