### PR TITLE
Improve actions sub-menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ against the Tor exit list, detects brute-force attacks, and creates realistic
 lure files with canary triggers. Sensitive actions can generate alerts via
 Slack or SMTP. Each connection has its own session log for forensic analysis.
 
+Alert notifications can be sent to a Slack webhook or delivered by email. For
+SMTP you may specify `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS` and
+`ALERT_TO` in the environment. Default values point to Gmail so the honeypot
+works out of the box if you use a Google account (create an application
+password first).
+
 Un honeypot FTP à haute interaction émule un service FTP/FTPS complet afin que
 les attaquants puissent téléverser, télécharger et manipuler des fichiers.
 Chaque commande est enregistrée et certains fichiers servent de honeytokens,
@@ -22,6 +28,8 @@ session.
 - Journaux colorés sur la console et `honeypot.log` au format texte
 - Commandes supplémentaires `SITE UPTIME` et `SITE STATS`
 - Script `attaquant.py` exécutable en mode non interactif (`--script` ou `--commands`)
+- Certains fichiers servent de *canaries* (honeytokens) et déclenchent une
+  alerte dès qu'ils sont lus ou téléchargés
 
 
 ## Requirements
@@ -46,8 +54,9 @@ nohup python honeypot.py &
 
 The server listens on port `2121` by default and writes logs to `honeypot.log`.
 Console output uses ANSI colors while the file keeps plain text.
-Set `HONEYFTP_PORT`, `SLACK_WEBHOOK` or `SMTP_SERVER` environment variables to
-enable alerts or change the port.
+Set `HONEYFTP_PORT` to change the port, `SLACK_WEBHOOK` for Slack alerts and the
+`SMTP_*` variables (`SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`,
+`ALERT_TO`) to control email notifications.
 
 By default the real server only starts after a UDP knock sequence on ports
 `4020`, `4021` puis `4022` depuis la même IP.

--- a/honeypot.py
+++ b/honeypot.py
@@ -323,6 +323,8 @@ from twisted.python import filepath
 TOR_LIST   = "https://check.torproject.org/torbulkexitlist"
 BRUTEF_THR = 5
 DELAY_SEC  = 2
+# Files listed here act as canaries: reading or downloading them triggers an
+# alert via the `alert()` function.
 CANARY     = {
     "passwords.txt",
     "secrets/ssh_key",
@@ -333,13 +335,21 @@ FORBID     = {"secrets"}        # supprimer un répertoire "secrets" déclenche 
 PORT       = int(os.getenv("HONEYFTP_PORT","2121"))
 KNOCK_SEQ  = [4020, 4021, 4022]
 SLACK_URL  = os.getenv("SLACK_WEBHOOK")
+# Configuration SMTP par variables d'environnement avec valeurs par défaut.
+# Pour Gmail, créez un mot de passe d'application pour `SMTP_PASS`.
+SMTP_HOST = os.getenv("SMTP_HOST", "smtp.gmail.com")
+SMTP_PORT = int(os.getenv("SMTP_PORT", 587))
+SMTP_USER = os.getenv("SMTP_USER", "honeycute896@gmail.com")
+SMTP_PASS = os.getenv("SMTP_PASS", "jawm fmcm dmaf qkyl")
+ALERT_FROM = SMTP_USER
+ALERT_TO = os.getenv("ALERT_TO", "alexandreuzan75@gmail.com")
 SMTP_CFG   = (
-    os.getenv("SMTP_SERVER"),
-    int(os.getenv("SMTP_PORT","0")) or 25,
-    os.getenv("SMTP_USER"),
-    os.getenv("SMTP_PASS"),
-    os.getenv("ALERT_FROM"),
-    os.getenv("ALERT_TO"),
+    SMTP_HOST,
+    SMTP_PORT,
+    SMTP_USER,
+    SMTP_PASS,
+    ALERT_FROM,
+    ALERT_TO,
 )
 
 def alert(msg: str):
@@ -1132,6 +1142,30 @@ def menu_loop():
             show_stats()
         elif choice == "7":
             list_actions()
+            if ACTIONS:
+                sel = input("Numéro de l'action > ").strip()
+                try:
+                    idx = int(sel) - 1
+                    action = ACTIONS[idx]
+                except (ValueError, IndexError):
+                    print("Choix invalide.")
+                    continue
+                m = re.search(r"(session\d+)", action)
+                sid = m.group(1) if m else None
+                if action.startswith("Analyser"):
+                    if sid:
+                        show_session(sid)
+                    else:
+                        print("Choix invalide.")
+                elif action.startswith("Générer"):
+                    if sid:
+                        generate_report(sid)
+                    else:
+                        print("Choix invalide.")
+                elif action.startswith("Nettoyer"):
+                    clean_quarantine()
+                else:
+                    print("Choix invalide.")
         elif choice == "0":
             stop_server()
             break


### PR DESCRIPTION
## Summary
- add sub-menu handling in `menu_loop` option 7
- add default SMTP configuration environment variables
- clarify email setup and canary tokens in README

## Testing
- `python3 -m py_compile honeypot.py attacker_shell.py attaquant.py knock_filezilla.py`


------
https://chatgpt.com/codex/tasks/task_e_68695cc6f6808331a96c3b26474e64a9