### PR TITLE
Fix root path for ls and cd

### DIFF
--- a/attaquant.py
+++ b/attaquant.py
@@ -98,7 +98,9 @@ def do_login(ftp, user, pwd):
 
 def do_nlst(ftp):
     try:
-        files = ftp.nlst('.')
+        # Pass an empty string so the server lists the root directory by
+        # default instead of the current directory indicator ``.'.``
+        files = ftp.nlst('')
         print(Fore.CYAN + "← FILES:")
         for i, f in enumerate(files, 1):
             print(f"   {i:2d}. {f}")


### PR DESCRIPTION
## Summary
- default to empty path for root listing
- handle empty `cd` using sendcmd
- adjust attacker script to use empty path for NLST